### PR TITLE
Fix context bleed

### DIFF
--- a/django_context_decorator.py
+++ b/django_context_decorator.py
@@ -19,8 +19,8 @@ class context:
 
         if not hasattr(owner, '_context_fields'):
             owner._context_fields = set()
-        elif not getattr(owner, '_context_copied', '') == owner.__name__:
-            setattr(owner, '_context_copied', owner.__name__)
+        elif getattr(owner, '_context_copied', '') is not owner:
+            setattr(owner, '_context_copied', owner)
             owner._context_fields = copy.deepcopy(owner._context_fields)
         owner._context_fields.add(name)
 

--- a/test_context_renaming.py
+++ b/test_context_renaming.py
@@ -1,0 +1,50 @@
+from django.conf import settings
+from django.test import RequestFactory
+from django.views.generic import TemplateView
+
+import django_context_decorator
+
+context = django_context_decorator.context
+
+try:
+    settings.configure()
+except RuntimeError:
+    pass
+
+
+class View(TemplateView):
+    template_name = '.html'
+
+    def __init__(self, request, **kwargs):
+        self.request = request
+        super().__init__(**kwargs)
+
+    @context
+    def foo(self):
+        return 'foo'
+
+
+NewView = View
+
+
+class View(NewView):
+    @context
+    def data(self):
+        return 'data'
+
+
+OtherView = View
+
+
+class View(OtherView):
+    @context
+    def other_data(self):
+        return 'data'
+
+
+def test_view_inheritance_with_renaming():
+
+    view = OtherView(RequestFactory().get(''))
+    context = view.get_context_data()
+    assert 'data' in context
+    assert 'other_data' not in context


### PR DESCRIPTION
This PR adds two commits:

* a test case that illustrates how the previous context bleed fix breaks when class names collide
* a fix for that test case.

While renaming classes the way the test case does isn't something that is likely to happen, the same problem could occur when importing view classes using `from something import View as BaseView`.