### PR TITLE
Suggestion for the recommended use of the pytest entry point

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,6 @@ All code resides in ``django_context_decorator.py``. Tests are collected by
 virtual environment, install the dependencies, and run ``pytest``::
 
     pip install django pytest pytest-cov
-    py.test --cov-report term --cov=django_context_decorator
+    pytest --cov-report term --cov=django_context_decorator
 
 .. _blog post: https://rixx.de/blog/a-context-decorator-for-django/


### PR DESCRIPTION
Hi, as of pytest version 3.0, the recommend entry point is **pytest** instead **py.test**
https://docs.pytest.org/en/latest/changelog.html#id765
"Introduce pytest command as recommended entry point. Note that py.test still works and is not scheduled for removal."