### PR TITLE
Fix operation for multiple inheritance

### DIFF
--- a/django_context_decorator.py
+++ b/django_context_decorator.py
@@ -19,9 +19,9 @@ class context:
 
         if not hasattr(owner, '_context_fields'):
             owner._context_fields = set()
-        elif getattr(owner, '_context_copied', '') is not owner:
-            setattr(owner, '_context_copied', owner)
+        elif getattr(owner, '_context_fields_owner', '') is not owner:
             owner._context_fields = copy.deepcopy(owner._context_fields)
+        setattr(owner, '_context_fields_owner', owner)
         owner._context_fields.add(name)
 
         if not getattr(owner, 'get_context_data', False):

--- a/test_mixins.py
+++ b/test_mixins.py
@@ -1,0 +1,30 @@
+from django.conf import settings
+from django.views.generic import TemplateView
+
+import django_context_decorator
+
+context = django_context_decorator.context
+
+
+class ViewMixin:
+    @context
+    def mixin_field(self):
+        return 'mixin'
+
+
+class BaseView(TemplateView):
+    @context
+    def base_field(self):
+        return 'base'
+
+
+class View(ViewMixin, BaseView):
+    pass
+
+
+def test_mixin_fields():
+    view = View()
+    context = view.get_context_data()
+
+    assert 'mixin_field' in context
+    assert 'base_field' in context


### PR DESCRIPTION
Update the module to work properly when the `context` decorator is used by multiple ancestors of a class.

Add a test which verifies correct operation.

Fixes: #6 